### PR TITLE
Add back the Fedora CMake command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ sudo dnf install cmake extra-cmake-modules "cmake(Qt5Core)" "cmake(Qt5Gui)" "cma
 sudo dnf install cmake extra-cmake-modules "cmake(Qt5Core)" "cmake(Qt5Gui)" "cmake(Qt5DBus)" "cmake(Qt5X11Extras)" "cmake(KF5GuiAddons)" "cmake(KF5WindowSystem)" "cmake(KF5I18n)" "cmake(KDecoration2)" "cmake(KF5CoreAddons)" "cmake(KF5ConfigWidgets)" "cmake(Qt5UiTools)" "cmake(KF5GlobalAccel)" "cmake(KF5IconThemes)" kwin-devel libepoxy-devel "cmake(KF5Init)" "cmake(KF5Crash)" "cmake(KF5KIO)" "cmake(KF5Notifications)" kf5-kpackage-devel
 ```
 
+> [!NOTE]
+> Building on Fedora requires the following CMake command to build properly.
+> This differs from the one being used in the Build and Install steps.
+
+`cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_LIBDIR=lib64 -DBUILD_TESTING=OFF .`
 
 <details>
 <summary><h4>Not tested</h4></summary>


### PR DESCRIPTION
Missing the cmake step for Fedora which is different to the one used in the Build and install steps.