### PR TITLE
Generalize build instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ git clone --single-branch --depth=1 https://github.com/Bali10050/Lightly.git
 cd Lightly && mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=lib -DBUILD_TESTING=OFF ..
 cd ./kdecoration/config/
-make -j 12
+make -j $(nproc)
 cd ../../
-make -j 12
+make -j $(nproc)
 sudo make install
 ```
 
@@ -69,9 +69,9 @@ git clone --single-branch --depth=1 https://github.com/Bali10050/Lightly.git
 cd Lightly && mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_LIBDIR=lib64 -DBUILD_TESTING=OFF ..
 cd ./kdecoration/config/
-make -j 12
+make -j $(nproc)
 cd ../../
-make -j 12
+make -j $(nproc)
 sudo make install
 ```
 
@@ -86,9 +86,9 @@ git clone --single-branch --depth=1 https://github.com/Bali10050/Lightly.git
 cd Lightly && mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_LIBDIR=lib64 -DBUILD_TESTING=OFF ..
 cd ./kdecoration/config/
-make -j 12
+make -j $(nproc)
 cd ../../
-make -j 12
+make -j $(nproc)
 sudo make install
 ```
 ***
@@ -103,9 +103,9 @@ git clone --single-branch --depth=1 https://github.com/Bali10050/Lightly.git
 cd Lightly && mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=lib -DBUILD_TESTING=OFF ..
 cd ./kdecoration/config/
-make -j 12
+make -j $(nproc)
 cd ../../
-make -j 12
+make -j $(nproc)
 sudo make install
 ```
 ***
@@ -132,9 +132,9 @@ cmake -DCMAKE_INSTALL_PREFIX=$HOME/.local \
       -DBUILD_TESTING=OFF ..
 
 cd ./kdecoration/config/
-make -j 12
+make -j $(nproc)
 cd ../../
-make -j 12
+make -j $(nproc)
 make install
 ```
 


### PR DESCRIPTION
This patch changes the make commands in the build instructions to use nproc which determines the number of processors (cores) on the system, instead of hard-coding 12.