### PR TITLE
Don't blur the entire region if alpha channel is < 255

### DIFF
--- a/.github/workflows/archlinux-ci.yml
+++ b/.github/workflows/archlinux-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install sudo, git and compile dependencies
         run: |
           pacman -Sy sudo git binutils make gcc pkg-config fakeroot \
-          cmake extra-cmake-modules \
+          cmake extra-cmake-modules qt6-base \
           kdecoration qt6-declarative kcoreaddons \
           kcmutils kcolorscheme kconfig kguiaddons \
           kiconthemes kwindowsystem --noconfirm

--- a/.github/workflows/lightly-ci.yml
+++ b/.github/workflows/lightly-ci.yml
@@ -78,9 +78,9 @@ jobs:
       cache-file-path: ${{ needs.release-ci.outputs.ASSET }}
       version: ${{ needs.release-ci.outputs.VERSION }}
 
-  Archlinux:
-    needs: release-ci
-    uses: ./.github/workflows/archlinux-ci.yml
-    with:
-      version: ${{ needs.release-ci.outputs.VERSION }}
+  # Archlinux:
+  #   needs: release-ci
+  #   uses: ./.github/workflows/archlinux-ci.yml
+  #   with:
+  #     version: ${{ needs.release-ci.outputs.VERSION }}
 

--- a/kstyle/lightlyblurhelper.cpp
+++ b/kstyle/lightlyblurhelper.cpp
@@ -173,9 +173,11 @@ namespace Lightly
         else 
             {
                 // blur entire window
+                // QT 6.8 now causes issues here when the alpha channel of the color scheme is < 255 with systemsettings
                 if( widget->palette().color( QPalette::Window ).alpha() < 255 )
-                    return roundedRegion(rect, StyleConfigData::cornerRadius(), false, false, true, true);
-                
+                    //return roundedRegion(rect, StyleConfigData::cornerRadius(), false, false, true, true);
+                    return QRegion();
+
                 // blur specific widgets
                 QRegion region;
                 


### PR DESCRIPTION
QT 6.8 changes may have introduced a regression in blurring windows so just return QRegion()
https://github.com/Bali10050/Lightly/issues/29

This may need reverting if the code is fixed in QT.

systemsettings opens with this small change.

If possible please test in a VM first.

I have also disabled the .zst Archlinux asset publishing since it doesn't work anymore.