### PR TITLE
Update to Fedora 41

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ sudo make install
 ***
 
 
-#### Distrobox (Fedora 40)
+#### Distrobox (Fedora 41)
 ```
-distrobox create --name lightly --image fedora-toolbox:40
+distrobox create --name lightly --image registry.fedoraproject.org/fedora-toolbox:41
 distrobox enter lightly
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ sudo make install
 
 #### Fedora
 
-#####  Fedora 40
+#####  Fedora 40/41
 
 ```
 sudo dnf install -y git cmake extra-cmake-modules "cmake(KDecoration2)" kwin-devel \


### PR DESCRIPTION
I tested the build instructions and all the dependencies seem to work fine in Fedora 41 so all this changes is the OS version in the instructions. If someone else wants to test this before it gets merged that would be great!