### PR TITLE
Menubar opacity and toolbar colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ This means that this fork allows real changes, and not just maintainence.
 
 ## Manual
 
+#### Void Linux
+```
+sudo xbps-install -Sy extra-cmake-modules base-devel qt6-base qt6-base-devel qt6-tools-devel kf6-kcmutils-devel kf6-kconfigwidgets-devel kf6-kdecoration-devel kf6-kirigami-devel kf6-kcoreaddons-devel kf6-kcolorscheme-devel kf6-kconfig-devel kf6-kguiaddons-devel kf6-ki18n-devel kf6-kiconthemes-devel kf6-kwindowsystem-devel kf6-frameworkintegration-devel kf6-karchive-devel kf6-kcodecs-devel kf6-kwidgetsaddons-devel qt6-declarative-devel qt6-svg-devel qt6-wayland-devel kf6-kwidgetsaddons-devel kf6-knotifications-devel
+```
+***
+
 #### Arch Linux
 
 ```

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ sudo make install
 
 #### Fedora
 
-#####  Fedora 40
+#####  Fedora 40/41
 
 ```
 sudo dnf install -y git cmake extra-cmake-modules "cmake(KDecoration2)" kwin-devel \
@@ -128,9 +128,9 @@ sudo make install
 ***
 
 
-#### Distrobox (Fedora 40)
+#### Distrobox (Fedora 41)
 ```
-distrobox create --name lightly --image fedora-toolbox:40
+distrobox create --name lightly --image registry.fedoraproject.org/fedora-toolbox:41
 distrobox enter lightly
 ```
 

--- a/kstyle/CMakeLists.txt
+++ b/kstyle/CMakeLists.txt
@@ -51,6 +51,7 @@ set(lightly_PART_SRCS
     lightlystyleplugin.cpp
     lightlytileset.cpp
     lightlywindowmanager.cpp
+    lightlytoolsareamanager.cpp
 )
 
 kconfig_add_kcfg_files(lightly_PART_SRCS ../kdecoration/lightlysettings.kcfgc)

--- a/kstyle/config/lightlystyleconfig.cpp
+++ b/kstyle/config/lightlystyleconfig.cpp
@@ -67,6 +67,11 @@ namespace Lightly
         connect( _sidebarOpacity, &QAbstractSlider::valueChanged, this, &StyleConfig::updateChanged );
         connect(_sidebarOpacity, SIGNAL(valueChanged(int)), _sidebarOpacitySpinBox, SLOT(setValue(int)));
         connect(_sidebarOpacitySpinBox, SIGNAL(valueChanged(int)), _sidebarOpacity, SLOT(setValue(int)));
+
+        connect(_menuBarOpacity, &QAbstractSlider::valueChanged, this, &StyleConfig::updateChanged);
+        connect(_menuBarOpacity, SIGNAL(valueChanged(int)), _menuBarOpacitySpinBox, SLOT(setValue(int)));
+        connect(_menuBarOpacitySpinBox, SIGNAL(valueChanged(int)), _menuBarOpacity, SLOT(setValue(int)));
+
         connect( _kTextEditDrawFrame, &QAbstractButton::toggled, this, &StyleConfig::updateChanged );
         connect( _widgetDrawShadow, &QAbstractButton::toggled, this, &StyleConfig::updateChanged );
         connect( _oldTabbar, &QAbstractButton::toggled, this, &StyleConfig::updateChanged );
@@ -96,6 +101,7 @@ namespace Lightly
         StyleConfigData::setWindowDragMode( _windowDragMode->currentIndex() );
         StyleConfigData::setMenuOpacity( _menuOpacity->value() );
         StyleConfigData::setDolphinSidebarOpacity( _sidebarOpacity->value() );
+        StyleConfigData::setMenuBarOpacity(_menuBarOpacity->value());
         StyleConfigData::setButtonSize( _buttonSize->value() );
         StyleConfigData::setKTextEditDrawFrame( _kTextEditDrawFrame->isChecked() );
         StyleConfigData::setWidgetDrawShadow( _widgetDrawShadow->isChecked() );
@@ -158,8 +164,11 @@ namespace Lightly
         else if( _sidebarOpacity->value() != StyleConfigData::dolphinSidebarOpacity() ) {
             modified = true;
             _sidebarOpacitySpinBox->setValue( _sidebarOpacity->value() );
-        } 
-        else if( _kTextEditDrawFrame->isChecked() != StyleConfigData::kTextEditDrawFrame() ) modified = true;
+        } else if (_menuBarOpacity->value() != StyleConfigData::menuBarOpacity()) {
+            modified = true;
+            _menuBarOpacitySpinBox->setValue(_menuBarOpacity->value());
+        } else if (_kTextEditDrawFrame->isChecked() != StyleConfigData::kTextEditDrawFrame())
+            modified = true;
         else if( _widgetDrawShadow->isChecked() != StyleConfigData::widgetDrawShadow() ) modified = true;
         else if( _oldTabbar->isChecked() != StyleConfigData::oldTabbar() ) modified = true;
         else if( _tabBarAltStyle->isChecked() != StyleConfigData::tabBarAltStyle() ) modified = true;
@@ -194,6 +203,10 @@ namespace Lightly
         _menuOpacitySpinBox->setValue( StyleConfigData::menuOpacity() );
         _sidebarOpacity->setValue( StyleConfigData::dolphinSidebarOpacity() );
         _sidebarOpacitySpinBox->setValue( StyleConfigData::dolphinSidebarOpacity() );
+
+        _menuBarOpacity->setValue(StyleConfigData::menuBarOpacity());
+        _menuBarOpacitySpinBox->setValue(StyleConfigData::menuBarOpacity());
+
         _buttonSize->setValue( StyleConfigData::buttonSize() );
         _kTextEditDrawFrame->setChecked( StyleConfigData::kTextEditDrawFrame() );
         _widgetDrawShadow->setChecked( StyleConfigData::widgetDrawShadow() );

--- a/kstyle/config/ui/lightlystyleconfig.ui
+++ b/kstyle/config/ui/lightlystyleconfig.ui
@@ -697,7 +697,7 @@
               <item>
                <widget class="QSlider" name="_menuOpacity">
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the menu items transparency&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>This changes the menu items transparency</string>
                 </property>
                 <property name="minimum">
                  <number>0</number>
@@ -755,7 +755,7 @@
               <item>
                <widget class="QSlider" name="_sidebarOpacity">
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the Dolphin sidebar transparency&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>This changes the Dolphin sidebar transparency</string>
                 </property>
                 <property name="maximum">
                  <number>100</number>

--- a/kstyle/config/ui/lightlystyleconfig.ui
+++ b/kstyle/config/ui/lightlystyleconfig.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>772</width>
-    <height>521</height>
+    <height>534</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -696,6 +696,9 @@
               </item>
               <item>
                <widget class="QSlider" name="_menuOpacity">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the menu items transparency&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
                 <property name="minimum">
                  <number>0</number>
                 </property>
@@ -751,6 +754,9 @@
               </item>
               <item>
                <widget class="QSlider" name="_sidebarOpacity">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This changes the Dolphin sidebar transparency&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
                 <property name="maximum">
                  <number>100</number>
                 </property>
@@ -785,6 +791,49 @@
               </item>
               <item>
                <widget class="QSpinBox" name="_sidebarOpacitySpinBox">
+                <property name="suffix">
+                 <string>%</string>
+                </property>
+                <property name="maximum">
+                 <number>100</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout">
+              <item>
+               <widget class="QLabel" name="label_7">
+                <property name="text">
+                 <string>Menubar:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSlider" name="_menuBarOpacity">
+                <property name="toolTip">
+                 <string>This only works on color schemes which support transparency</string>
+                </property>
+                <property name="maximum">
+                 <number>100</number>
+                </property>
+                <property name="value">
+                 <number>100</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+                <property name="tickPosition">
+                 <enum>QSlider::TickPosition::TicksBelow</enum>
+                </property>
+                <property name="tickInterval">
+                 <number>10</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="_menuBarOpacitySpinBox">
                 <property name="suffix">
                  <string>%</string>
                 </property>

--- a/kstyle/lightly.h
+++ b/kstyle/lightly.h
@@ -40,12 +40,11 @@ namespace Lightly
     //@}
 
     //* metrics
-    enum Metrics
-    {
+    enum Metrics {
 
         // frames
         Frame_FrameWidth = 5,
-        //Frame_FrameRadius = 6,
+        // Frame_FrameRadius = 6,
 
         // layout
         Layout_TopLevelMarginWidth = 10,
@@ -85,7 +84,7 @@ namespace Lightly
         ToolButton_InlineIndicatorWidth = 12,
 
         // checkboxes and radio buttons
-        CheckBox_Size = 16 + ( Frame_FrameWidth - 1 )*2,
+        CheckBox_Size = 16 + (Frame_FrameWidth - 1) * 2,
         CheckBox_FocusMarginWidth = 2,
         CheckBox_ItemSpacing = 4,
 
@@ -97,9 +96,9 @@ namespace Lightly
         ScrollBar_Extend = 21,
         ScrollBar_SliderWidth = 8,
         ScrollBar_MinSliderHeight = 20,
-        ScrollBar_NoButtonHeight = (ScrollBar_Extend-ScrollBar_SliderWidth)/2,
+        ScrollBar_NoButtonHeight = (ScrollBar_Extend - ScrollBar_SliderWidth) / 2,
         ScrollBar_SingleButtonHeight = ScrollBar_Extend,
-        ScrollBar_DoubleButtonHeight = 2*ScrollBar_Extend,
+        ScrollBar_DoubleButtonHeight = 2 * ScrollBar_Extend,
 
         // toolbars
         ToolBar_FrameWidth = 2,
@@ -108,6 +107,7 @@ namespace Lightly
         ToolBar_SeparatorWidth = 8,
         ToolBar_ExtensionWidth = 20,
         ToolBar_ItemSpacing = 0,
+        ToolBar_SeparatorVerticalMargin = 2,
 
         // progressbars
         ProgressBar_BusyIndicatorSize = 14,

--- a/kstyle/lightly.kcfg
+++ b/kstyle/lightly.kcfg
@@ -215,7 +215,7 @@
     </entry>
     
     <entry name="ForceOpaque" type="StringList">
-       <default>kscreenlocker,wine,vlc,kdevelop,smplayer,virtualbox,virtualboxvm,obs,kaffeine,kate,kstars,digikam,kdenlive</default>
+       <default>kscreenlocker,wine,vlc,kdevelop,smplayer,virtualbox,virtualboxvm,obs,kaffeine,kstars,digikam,kdenlive</default>
     </entry>
 
     <!-- if true, move events are passed to the window manager (e.g. KWin) -->

--- a/kstyle/lightly.kcfg
+++ b/kstyle/lightly.kcfg
@@ -250,6 +250,10 @@
         <default>100</default>
     </entry>
 
+    <entry name="MenuBarOpacity" type="Int">
+      <default>100</default>
+    </entry>
+
   </group>
 
 </kcfg>

--- a/kstyle/lightlyblurhelper.cpp
+++ b/kstyle/lightlyblurhelper.cpp
@@ -137,8 +137,6 @@ namespace Lightly
                 // cast to widget and check
                 QWidget* widget(qobject_cast<QWidget*>(object));
 
-                if (!widget || !widget->isWindow()) break;
-
                 if (!widget)
                     break;
 
@@ -174,102 +172,89 @@ namespace Lightly
         } 
         else 
             {
-                // blur entire window
-                // QT 6.8 now causes issues here when the alpha channel of the color scheme is < 255 with systemsettings
-                if( widget->palette().color( QPalette::Window ).alpha() < 255 )
-                    return roundedRegion(rect, StyleConfigData::cornerRadius(), false, false, true, true);
+            // blur entire window
+            // is this a QT 6.8 regression causing systemssettings to appear blurred ?
+            // if( widget->palette().color( QPalette::Window ).alpha() < 255 )
+            //    return roundedRegion(rect, StyleConfigData::cornerRadius(), false, false, true, true);
 
-                // blur specific widgets
-                QRegion region;
-                
-                // toolbar and menubar
-                if( _translucentTitlebar )
-                {
-                    // menubar
-                    int menubarHeight = 0;
-                    if ( QMainWindow *mw = qobject_cast<QMainWindow*>( widget ) )
-                    {
-                        if ( QWidget *mb = mw->menuWidget() ) 
-                        {
-                            if ( mb->isVisible() )
-                            {
-                                region += mb->rect();
-                                menubarHeight = mb->height();
-                            }
+            // blur specific widgets
+            QRegion region;
+
+            // toolbar and menubar
+            if (_translucentTitlebar) {
+                // menubar
+                int menubarHeight = 0;
+                if (QMainWindow *mw = qobject_cast<QMainWindow *>(widget)) {
+                    if (QWidget *mb = mw->menuWidget()) {
+                        if (mb->isVisible()) {
+                            region += mb->rect();
+                            menubarHeight = mb->height();
                         }
-                    }
-                
-                    QList<QToolBar *> toolbars = widget->window()->findChildren<QToolBar *>( QString(), Qt::FindDirectChildrenOnly );
-                    QRect mainToolbar = QRect();
-                    
-                    // just assuming
-                    Qt::Orientation orientation = Qt::Vertical;
-                    
-                    // find which one is the main toolbar
-                    for( auto tb : toolbars )
-                    {
-                        // single toolbar
-                        if ( tb && tb->isVisible() && toolbars.length() == 1 ) {
-                            region += QRegion( QRect( tb->pos(), tb->rect().size() ) );
-                            orientation = tb->orientation();
-                        }
-                        
-                        else if ( tb && tb->isVisible() )
-                        {
-                            if( mainToolbar.isNull() ) {
-                                mainToolbar = QRect( tb->pos(), tb->rect().size() );
-                                orientation = tb->orientation();
-                            }
-                            
-                            // test against the previous best caditate
-                            else
-                            {
-                                if( (tb->y() < mainToolbar.y()) || (tb->y() == mainToolbar.y() && tb->x() < mainToolbar.x()) ) {
-                                    mainToolbar = QRect( tb->pos(), tb->rect().size() );
-                                    orientation = tb->orientation();
-                                }
-                            }
-                        }
-                    }
-                    
-                    if ( mainToolbar.isValid() )
-                    {
-    
-                        // make adjustments
-                        if( orientation == Qt::Horizontal )
-                        {
-                            // toolbar may be at the top but not ocupy the whole avaliable width
-                            // so we blur the whole area instead
-                            if( mainToolbar.y() == 0 || mainToolbar.y() == menubarHeight )
-                            {
-                                mainToolbar.setX( 0 );
-                                mainToolbar.setWidth( widget->width() );
-                                region += mainToolbar;
-                            }
-                            
-                            // round corners if it is at the bottom
-                            else if ( mainToolbar.y() + mainToolbar.height() == widget->height() )
-                                region += roundedRegion( mainToolbar, StyleConfigData::cornerRadius(),  false, false, false, true );
-                            
-                            //else
-                            //    region += mainToolbar;
-                            
-                        } else {
-                            
-                            // round bottom left
-                            if( mainToolbar.x() == 0 ) 
-                                region += roundedRegion( mainToolbar, StyleConfigData::cornerRadius(),  false, false, true, false );
-                            
-                            // round bottom right
-                            else if( mainToolbar.x() + mainToolbar.width() == widget->width() ) 
-                                region += roundedRegion( mainToolbar, StyleConfigData::cornerRadius(),  false, false, false, true );
-                            
-                            // no round corners
-                            //else region += mainToolbar; //FIXME: is this valid?
-                        }
-                        
                     }
                 }
+
+                QList<QToolBar *> toolbars = widget->window()->findChildren<QToolBar *>(QString(), Qt::FindDirectChildrenOnly);
+                QRect mainToolbar = QRect();
+
+                // just assuming
+                Qt::Orientation orientation = Qt::Vertical;
+
+                // find which one is the main toolbar
+                for (auto tb : toolbars) {
+                    // single toolbar
+                    if (tb && tb->isVisible() && toolbars.length() == 1) {
+                        region += QRegion(QRect(tb->pos(), tb->rect().size()));
+                        orientation = tb->orientation();
+                    }
+
+                    else if (tb && tb->isVisible()) {
+                        if (mainToolbar.isNull()) {
+                            mainToolbar = QRect(tb->pos(), tb->rect().size());
+                            orientation = tb->orientation();
+                        }
+
+                        // test against the previous best caditate
+                        else {
+                            if ((tb->y() < mainToolbar.y()) || (tb->y() == mainToolbar.y() && tb->x() < mainToolbar.x())) {
+                                mainToolbar = QRect(tb->pos(), tb->rect().size());
+                                orientation = tb->orientation();
+                            }
+                        }
+                    }
+                }
+
+                if (mainToolbar.isValid()) {
+                    // make adjustments
+                    if (orientation == Qt::Horizontal) {
+                        // toolbar may be at the top but not ocupy the whole avaliable width
+                        // so we blur the whole area instead
+                        if (mainToolbar.y() == 0 || mainToolbar.y() == menubarHeight) {
+                            mainToolbar.setX(0);
+                            mainToolbar.setWidth(widget->width());
+                            region += mainToolbar;
+                        }
+
+                        // round corners if it is at the bottom
+                        else if (mainToolbar.y() + mainToolbar.height() == widget->height())
+                            region += roundedRegion(mainToolbar, StyleConfigData::cornerRadius(), false, false, false, true);
+
+                        // else
+                        //     region += mainToolbar;
+
+                    } else {
+                        // round bottom left
+                        if (mainToolbar.x() == 0)
+                            region += roundedRegion(mainToolbar, StyleConfigData::cornerRadius(), false, false, true, false);
+
+                        // round bottom right
+                        else if (mainToolbar.x() + mainToolbar.width() == widget->width())
+                            region += roundedRegion(mainToolbar, StyleConfigData::cornerRadius(), false, false, false, true);
+
+                        // no round corners
+                        // else region += mainToolbar; //FIXME: is this valid?
+                    }
+                }
+            }
 
                 // dolphin's sidebar
                 if( StyleConfigData::dolphinSidebarOpacity() < 100 )

--- a/kstyle/lightlyhelper.cpp
+++ b/kstyle/lightlyhelper.cpp
@@ -37,6 +37,7 @@
 #include <QX11Info>
 #endif
 
+#include <QDialog>
 #include <algorithm>
 
 //#include <QDebug>
@@ -1937,5 +1938,44 @@ namespace Lightly
             }
         }
         return pixmap;
+    }
+
+    bool Helper::shouldDrawToolsArea(const QWidget *widget) const
+    {
+        if (!widget) {
+            return false;
+        }
+        static bool isAuto = false;
+        static QString borderSize;
+        if (!_cachedAutoValid) {
+            KConfigGroup kdecorationGroup(_config->group(QStringLiteral("org.kde.kdecoration2")));
+            isAuto = kdecorationGroup.readEntry("BorderSizeAuto", true);
+            borderSize = kdecorationGroup.readEntry("BorderSize", "Normal");
+            _cachedAutoValid = true;
+        }
+        if (isAuto) {
+            auto window = widget->window();
+            if (qobject_cast<const QDialog *>(widget)) {
+                return true;
+            }
+            if (window) {
+                auto handle = window->windowHandle();
+                if (handle) {
+                    auto toolbar = qobject_cast<const QToolBar *>(widget);
+                    if (toolbar) {
+                        if (toolbar->isFloating()) {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+            } else {
+                return false;
+            }
+        }
+        if (borderSize != "None" && borderSize != "NoSides") {
+            return false;
+        }
+        return true;
     }
 }

--- a/kstyle/lightlyhelper.h
+++ b/kstyle/lightlyhelper.h
@@ -31,8 +31,9 @@
 #include <KColorScheme>
 #include <KSharedConfig>
 #include <KStatefulBrush>
-#include <QPainterPath>
 #include <QIcon>
+#include <QPainterPath>
+#include <QToolBar>
 #include <QWidget>
 
 namespace Lightly
@@ -289,7 +290,9 @@ namespace Lightly
         //* returns true if a given palette has dark colors 
         bool isDarkTheme( const QPalette& palette) const
         { return qGray( palette.color( QPalette::Window ).rgb() ) > 110 ? false : true; }
-        
+
+        //* returns true if the tools area should be drawn
+        bool shouldDrawToolsArea(const QWidget *) const;
 
         //@}
 
@@ -339,6 +342,8 @@ namespace Lightly
         QColor _inactiveTitleBarTextColor;
         //@}
 
+        mutable bool _cachedAutoValid = false;
+        friend class ToolsAreaManager;
     };
 
 }

--- a/kstyle/lightlypropertynames.cpp
+++ b/kstyle/lightlypropertynames.cpp
@@ -33,4 +33,5 @@ namespace Lightly
     const char PropertyNames::alteredBackground[] = "_lightly_altered_background";
     const char PropertyNames::forceFrame[] = "_breeze_force_frame";
     const char PropertyNames::bordersSides[] = "_breeze_borders_sides";
+    const char PropertyNames::noSeparator[] = "_lightly_no_separator";
 }

--- a/kstyle/lightlypropertynames.h
+++ b/kstyle/lightlypropertynames.h
@@ -36,6 +36,7 @@ namespace Lightly
         static const char alteredBackground[];
         static const char bordersSides[];
         static const char forceFrame[];
+        static const char noSeparator[];
     };
 
 }

--- a/kstyle/lightlystyle.cpp
+++ b/kstyle/lightlystyle.cpp
@@ -21,6 +21,7 @@
 
 #include "lightly.h"
 #include "lightlyanimations.h"
+#include "lightlyblurhelper.h"
 #include "lightlyframeshadow.h"
 #include "lightlymdiwindowshadow.h"
 #include "lightlymnemonics.h"
@@ -28,35 +29,39 @@
 #include "lightlyshadowhelper.h"
 #include "lightlysplitterproxy.h"
 #include "lightlystyleconfigdata.h"
+#include "lightlytoolsareamanager.h"
 #include "lightlywidgetexplorer.h"
 #include "lightlywindowmanager.h"
-#include "lightlyblurhelper.h"
 
 #include <KColorUtils>
 
 #include <QApplication>
 #include <QCheckBox>
 #include <QComboBox>
-#include <QDial>
 #include <QDBusConnection>
+#include <QDial>
+#include <QDialog>
+#include <QDialogButtonBox>
 #include <QDockWidget>
 #include <QFormLayout>
 #include <QGraphicsView>
 #include <QGroupBox>
+#include <QItemDelegate>
 #include <QLabel>
 #include <QLineEdit>
 #include <QListWidget>
 #include <QMainWindow>
+#include <QMap>
 #include <QMdiSubWindow>
 #include <QMenu>
 #include <QMenuBar>
-#include <QMap>
 #include <QPainter>
 #include <QPushButton>
 #include <QRadioButton>
 #include <QScrollBar>
-#include <QItemDelegate>
 #include <QSplitterHandle>
+#include <QStackedLayout>
+#include <QSurfaceFormat>
 #include <QTableView>
 #include <QTextEdit>
 #include <QToolBar>
@@ -64,10 +69,7 @@
 #include <QToolButton>
 #include <QTreeView>
 #include <QWidgetAction>
-#include <QSurfaceFormat>
 #include <QWindow>
-#include <QDialogButtonBox>
-#include <QStackedLayout>
 
 #if LIGHTLY_HAVE_QTQUICK
 #include <QQuickWindow>
@@ -168,46 +170,50 @@ namespace LightlyPrivate
 namespace Lightly
 {
     //______________________________________________________________
-    Style::Style():
+Style::Style()
+    :
 
-        _helper( new Helper( StyleConfigData::self()->sharedConfig() ) )
-        , _shadowHelper( new ShadowHelper( this, *_helper ) )
-        , _animations( new Animations( this ) )
-        , _mnemonics( new Mnemonics( this ) )
-        , _blurHelper( new BlurHelper( this ) )
-        , _windowManager( new WindowManager( this ) )
-        , _frameShadowFactory( new FrameShadowFactory( this ) )
-        , _mdiWindowShadowFactory( new MdiWindowShadowFactory( this ) )
-        , _splitterFactory( new SplitterFactory( this ) )
-        , _widgetExplorer( new WidgetExplorer( this ) )
-        , _tabBarData( new LightlyPrivate::TabBarData( this ) )
-        #if LIGHTLY_HAVE_KSTYLE
-        , SH_ArgbDndWindow( newStyleHint( QStringLiteral( "SH_ArgbDndWindow" ) ) )
-        , CE_CapacityBar( newControlElement( QStringLiteral( "CE_CapacityBar" ) ) )
-        #endif
-    {
+    _helper(new Helper(StyleConfigData::self()->sharedConfig()))
+    , _shadowHelper(new ShadowHelper(this, *_helper))
+    , _animations(new Animations(this))
+    , _mnemonics(new Mnemonics(this))
+    , _blurHelper(new BlurHelper(this))
+    , _windowManager(new WindowManager(this))
+    , _frameShadowFactory(new FrameShadowFactory(this))
+    , _mdiWindowShadowFactory(new MdiWindowShadowFactory(this))
+    , _splitterFactory(new SplitterFactory(this))
+    , _toolsAreaManager(new ToolsAreaManager(_helper, this))
+    , _widgetExplorer(new WidgetExplorer(this))
+    , _tabBarData(new LightlyPrivate::TabBarData(this))
+#if LIGHTLY_HAVE_KSTYLE
+    , SH_ArgbDndWindow(newStyleHint(QStringLiteral("SH_ArgbDndWindow")))
+    , CE_CapacityBar(newControlElement(QStringLiteral("CE_CapacityBar")))
+#endif
+{
+    // use DBus connection to update on lightly configuration change
+    auto dbus = QDBusConnection::sessionBus();
+    dbus.connect(QString(),
+                 QStringLiteral("/LightlyStyle"),
+                 QStringLiteral("org.kde.Lightly.Style"),
+                 QStringLiteral("reparseConfiguration"),
+                 this,
+                 SLOT(configurationChanged()));
 
-        // use DBus connection to update on lightly configuration change
-        auto dbus = QDBusConnection::sessionBus();
-        dbus.connect( QString(),
-            QStringLiteral( "/LightlyStyle" ),
-            QStringLiteral( "org.kde.Lightly.Style" ),
-            QStringLiteral( "reparseConfiguration" ), this, SLOT(configurationChanged()) );
-
-        dbus.connect( QString(),
-            QStringLiteral( "/LightlyDecoration" ),
-            QStringLiteral( "org.kde.Lightly.Style" ),
-            QStringLiteral( "reparseConfiguration" ), this, SLOT(configurationChanged()) );
-        #if QT_VERSION < 0x050D00 // Check if Qt version < 5.13
-        this->addEventFilter(qApp);
-        #else
-        connect(qApp, &QApplication::paletteChanged, this, &Style::configurationChanged);
-        #endif
-        // call the slot directly; this initial call will set up things that also
-        // need to be reset when the system palette changes
-        loadConfiguration();
-
-    }
+    dbus.connect(QString(),
+                 QStringLiteral("/LightlyDecoration"),
+                 QStringLiteral("org.kde.Lightly.Style"),
+                 QStringLiteral("reparseConfiguration"),
+                 this,
+                 SLOT(configurationChanged()));
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    this->addEventFilter(qApp);
+#else
+    connect(qApp, &QApplication::paletteChanged, this, &Style::configurationChanged);
+#endif
+    // call the slot directly; this initial call will set up things that also
+    // need to be reset when the system palette changes
+    loadConfiguration();
+}
 
     //______________________________________________________________
     Style::~Style()
@@ -245,6 +251,8 @@ namespace Lightly
             _isOpaque = true;
         if(_translucentWidgets.size() > 0) _translucentWidgets.clear();
 
+        _toolsAreaManager->registerApplication(app);
+
         // base class polishing
         ParentStyleClass::polish( app );
     }
@@ -261,6 +269,7 @@ namespace Lightly
         _mdiWindowShadowFactory->registerWidget( widget );
         _shadowHelper->registerWidget( widget );
         _splitterFactory->registerWidget( widget );
+        _toolsAreaManager->registerWidget(widget);
 
         // enable mouse over effects for all necessary widgets
         if(
@@ -485,8 +494,23 @@ namespace Lightly
 
             setTranslucentBackground( widget );
 
+        } else if (qobject_cast<QMainWindow *>(widget)) {
+            widget->setAttribute(Qt::WA_StyledBackground);
         } else if (qobject_cast<QDialogButtonBox *>(widget)) {
             addEventFilter(widget);
+        }
+
+        if (_toolsAreaManager->hasHeaderColors()) {
+            // style TitleWidget and Search KPageView to look the same as KDE System Settings
+            if (widget->objectName() == QLatin1String("KPageView::TitleWidget")) {
+                widget->setAutoFillBackground(true);
+                widget->setPalette(_toolsAreaManager->palette());
+                addEventFilter(widget);
+            } else if (widget->objectName() == QLatin1String("KPageView::Search")) {
+                widget->setBackgroundRole(QPalette::Window);
+                widget->setPalette(_toolsAreaManager->palette());
+                addEventFilter(widget);
+            }
         }
 
         // base class polishing
@@ -579,6 +603,7 @@ namespace Lightly
         _windowManager->unregisterWidget( widget );
         _splitterFactory->unregisterWidget( widget );
         _blurHelper->unregisterWidget( widget );
+        _toolsAreaManager->unregisterWidget(widget);
 
         // remove event filter
         if( qobject_cast<QAbstractScrollArea*>( widget ) ||
@@ -1032,6 +1057,9 @@ namespace Lightly
             case PE_FrameTabBarBase: fcn = &Style::drawFrameTabBarBasePrimitive; break;
             case PE_FrameWindow: fcn = &Style::drawFrameWindowPrimitive; break;
             case PE_FrameFocusRect: fcn = _frameFocusPrimitive; break;
+            case PE_Widget:
+                fcn = &Style::drawWidgetPrimitive;
+                break;
 
             // fallback
             default: break;
@@ -1046,6 +1074,113 @@ namespace Lightly
 
         painter->restore();
 
+    }
+
+    //______________________________________________________________
+    bool Style::drawWidgetPrimitive(const QStyleOption *option, QPainter *painter, const QWidget *widget) const
+    {
+        Q_UNUSED(option)
+
+        const auto drawBackground = _toolsAreaManager->hasHeaderColors() && _helper->shouldDrawToolsArea(widget);
+
+        auto mw = qobject_cast<const QMainWindow *>(widget);
+        if (mw && mw == mw->window()) {
+            painter->save();
+
+            auto rect = _toolsAreaManager->toolsAreaRect(mw);
+
+            if (rect.height() == 0) {
+                if (mw->property(PropertyNames::noSeparator).toBool() || mw->isFullScreen()) {
+                    painter->restore();
+                    return true;
+                }
+                painter->setPen(QPen(_helper->separatorColor(_toolsAreaManager->palette()), PenWidth::Frame * widget->devicePixelRatio()));
+                painter->drawLine(widget->rect().topLeft(), widget->rect().topRight());
+                painter->restore();
+                return true;
+            }
+
+            auto color = _toolsAreaManager->palette().brush(mw->isActiveWindow() ? QPalette::Active : QPalette::Inactive, QPalette::Window);
+
+            if (drawBackground) {
+                painter->setPen(Qt::transparent);
+                painter->setBrush(color);
+                painter->drawRect(rect);
+            }
+
+            painter->setPen(_helper->separatorColor(_toolsAreaManager->palette()));
+            painter->drawLine(rect.bottomLeft(), rect.bottomRight());
+
+            painter->restore();
+        } else if (auto dialog = qobject_cast<const QDialog *>(widget)) {
+            if (dialog->isFullScreen()) {
+                return true;
+            }
+            if (auto vLayout = qobject_cast<QVBoxLayout *>(widget->layout())) {
+                QRect rect(0, 0, widget->width(), 0);
+                const auto color = _toolsAreaManager->palette().brush(widget->isActiveWindow() ? QPalette::Active : QPalette::Inactive, QPalette::Window);
+
+                if (vLayout->menuBar()) {
+                    rect.setHeight(rect.height() + vLayout->menuBar()->rect().height());
+                }
+
+                for (int i = 0, count = vLayout->count(); i < count; i++) {
+                    const auto layoutItem = vLayout->itemAt(i);
+                    if (layoutItem->widget() && qobject_cast<QToolBar *>(layoutItem->widget())) {
+                        rect.setHeight(rect.height() + layoutItem->widget()->rect().height() + vLayout->spacing());
+                    } else {
+                        break;
+                    }
+                }
+
+                if (rect.height() > 0) {
+                    // We found either a QMenuBar or a QToolBar
+
+                    // Add contentsMargins + separator
+                    rect.setHeight(rect.height() + widget->devicePixelRatio() + vLayout->contentsMargins().top());
+
+                    if (drawBackground) {
+                        painter->setPen(Qt::transparent);
+                        painter->setBrush(color);
+                        painter->drawRect(rect);
+                    }
+
+                    painter->setPen(QPen(_helper->separatorColor(_toolsAreaManager->palette()), widget->devicePixelRatio()));
+                    painter->drawLine(rect.bottomLeft(), rect.bottomRight());
+
+                    return true;
+                }
+            }
+
+            painter->setPen(QPen(_helper->separatorColor(_toolsAreaManager->palette()), PenWidth::Frame * widget->devicePixelRatio()));
+            painter->drawLine(widget->rect().topLeft(), widget->rect().topRight());
+        } else if (widget && widget->inherits("KMultiTabBar")) {
+            enum class Position {
+                Left,
+                Right,
+                Top,
+                Bottom,
+            };
+
+            const Position position = static_cast<Position>(widget->property("position").toInt());
+            const auto splitterWidth = Metrics::Splitter_SplitterWidth;
+            QRect rect = option->rect;
+
+            if (position == Position::Top || position == Position::Bottom) {
+                return true;
+            }
+
+            if ((position == Position::Left && widget->layoutDirection() == Qt::LeftToRight)
+                || (position == Position::Right && widget->layoutDirection() == Qt::RightToLeft)) {
+                rect.setX(rect.width() - splitterWidth);
+            }
+
+            rect.setWidth(splitterWidth);
+
+            const auto color(_helper->separatorColor(option->palette));
+            _helper->renderSeparator(painter, rect, color, true);
+        }
+        return true;
     }
 
     //______________________________________________________________
@@ -1309,6 +1444,37 @@ namespace Lightly
             // define color and render
             const auto color(_helper->separatorColor(palette));
             _helper->renderSeparator(&painter, rect, color, false);
+        }
+
+        return false;
+    }
+
+    //____________________________________________________________________________
+    bool Style::eventFilterPageViewHeader(QWidget *widget, QEvent *event)
+    {
+        if (event->type() == QEvent::Paint) {
+            QPainter painter(widget);
+            const auto &palette(_toolsAreaManager->palette());
+
+            painter.setBrush(palette.color(QPalette::Window));
+            painter.setPen(Qt::NoPen);
+            painter.drawRect(widget->rect());
+
+            // Add separator next to the search field
+            if (widget->objectName() == QLatin1String("KPageView::Search")) {
+                auto rect(widget->rect());
+                if (widget->layoutDirection() == Qt::RightToLeft) {
+                    rect.setWidth(1);
+                } else {
+                    rect.setLeft(rect.width() - 1);
+                }
+                rect.setHeight(rect.height() - Metrics::ToolBar_SeparatorVerticalMargin * 2);
+                rect.setY(Metrics::ToolBar_SeparatorVerticalMargin);
+
+                // define color and render
+                const auto color(_helper->separatorColor(palette));
+                _helper->renderSeparator(&painter, rect, color, true);
+            }
         }
 
         return false;

--- a/kstyle/lightlystyle.cpp
+++ b/kstyle/lightlystyle.cpp
@@ -5178,16 +5178,33 @@ Style::Style()
         const bool windowActive( widget && widget->isActiveWindow() );
 
         const auto& rect( option->rect );
-        
-        _helper->renderTransparentArea( painter, rect );
-        
+        const auto &palette(option->palette);
+
         // draw background
-        int opacity = _helper->titleBarColor( windowActive ).alphaF()*100.0;
 
-        // painter->fillRect(rect, _helper->alphaColor(option->palette.color( QPalette::Window ), opacity) );
+        // changes menubar background opacity
 
-        // this paints the menubar with the same color from the titlebar
-        painter->fillRect(rect, _helper->titleBarColor(windowActive));
+        if (widget && _helper->titleBarColor(windowActive).alphaF() * 100.0 < 100 && _translucentWidgets.contains(widget->window())) {
+            _helper->renderTransparentArea(painter, rect);
+
+            float opacity = 0.0;
+            QColor background(palette.color(QPalette::Window));
+
+            if (StyleConfigData::menuBarOpacity() == 100) {
+                // opacity is at 100%
+                opacity = 1.0;
+                background.setAlphaF(opacity);
+                painter->fillRect(rect, background);
+            } else if (StyleConfigData::menuBarOpacity() == 0) {
+                background.setAlphaF(_helper->titleBarColor(windowActive).alphaF());
+                painter->fillRect(rect, background);
+            } else if (StyleConfigData::menuBarOpacity() < 100 && StyleConfigData::menuBarOpacity() > 0) {
+                // lower the opacity
+                opacity = StyleConfigData::menuBarOpacity() / 100.0;
+                background.setAlphaF(opacity);
+                painter->fillRect(rect, background);
+            }
+        }
 
         bool shouldDrawShadow = false;
         if ( LightlyPrivate::possibleTranslucentToolBars.isEmpty() ) shouldDrawShadow = true;
@@ -5249,13 +5266,32 @@ Style::Style()
         {
             
             _helper->renderTransparentArea( painter, rect );
-
-            // draw background
-            int opacity = _helper->titleBarColor( windowActive ).alphaF()*100.0;
-            // painter->fillRect(rect, _helper->alphaColor(option->palette.color( QPalette::Window ), opacity) );
+            float opacity = 0.0;
 
             // this paints the menubar with the same color from the titlebar
-            painter->fillRect(rect, _helper->titleBarColor(windowActive));
+            // painter->fillRect(rect, _helper->titleBarColor(windowActive));
+
+            // 100% opacity = no transparency
+
+            QColor background(palette.color(QPalette::Window));
+
+            // changes menubar background opacity
+
+            if (StyleConfigData::menuBarOpacity() == 100) {
+                // opacity is at 100%
+                opacity = 1.0;
+                background.setAlphaF(opacity);
+                painter->fillRect(rect, background);
+            } else if (StyleConfigData::menuBarOpacity() == 0) {
+                // use the same titlebar color
+                background.setAlphaF(_helper->titleBarColor(windowActive).alphaF());
+                painter->fillRect(rect, background);
+            } else if (StyleConfigData::menuBarOpacity() < 100 && StyleConfigData::menuBarOpacity() > 0) {
+                // lower the opacity
+                opacity = StyleConfigData::menuBarOpacity() / 100.0;
+                background.setAlphaF(opacity);
+                painter->fillRect(rect, background);
+            }
 
             bool shouldDrawShadow = false;
             int shadow_xoffset = 0;

--- a/kstyle/lightlystyle.cpp
+++ b/kstyle/lightlystyle.cpp
@@ -5183,8 +5183,12 @@ Style::Style()
         
         // draw background
         int opacity = _helper->titleBarColor( windowActive ).alphaF()*100.0;
-        painter->fillRect(rect, _helper->alphaColor(option->palette.color( QPalette::Window ), opacity) );
-        
+
+        // painter->fillRect(rect, _helper->alphaColor(option->palette.color( QPalette::Window ), opacity) );
+
+        // this paints the menubar with the same color from the titlebar
+        painter->fillRect(rect, _helper->titleBarColor(windowActive));
+
         bool shouldDrawShadow = false;
         if ( LightlyPrivate::possibleTranslucentToolBars.isEmpty() ) shouldDrawShadow = true;
         
@@ -5248,8 +5252,11 @@ Style::Style()
 
             // draw background
             int opacity = _helper->titleBarColor( windowActive ).alphaF()*100.0;
-            painter->fillRect(rect, _helper->alphaColor(option->palette.color( QPalette::Window ), opacity) );
-            
+            // painter->fillRect(rect, _helper->alphaColor(option->palette.color( QPalette::Window ), opacity) );
+
+            // this paints the menubar with the same color from the titlebar
+            painter->fillRect(rect, _helper->titleBarColor(windowActive));
+
             bool shouldDrawShadow = false;
             int shadow_xoffset = 0;
             if ( LightlyPrivate::possibleTranslucentToolBars.isEmpty() ) shouldDrawShadow = true;

--- a/kstyle/lightlystyle.h
+++ b/kstyle/lightlystyle.h
@@ -62,6 +62,7 @@ namespace Lightly
     class WidgetExplorer;
     class WindowManager;
     class BlurHelper;
+    class ToolsAreaManager;
 
     //* convenience typedef for base class
     #if !LIGHTLY_HAVE_KSTYLE
@@ -145,6 +146,7 @@ namespace Lightly
         bool eventFilterMdiSubWindow( QMdiSubWindow*, QEvent* );
         bool eventFilterCommandLinkButton( QCommandLinkButton*, QEvent* );
         bool eventFilterDialogButtonBox(QDialogButtonBox *, QEvent *);
+        bool eventFilterPageViewHeader(QWidget *, QEvent *);
 
         //* install event filter to object, in a unique way
         void addEventFilter( QObject* object )
@@ -251,6 +253,7 @@ namespace Lightly
         bool drawFrameTabWidgetPrimitive( const QStyleOption*, QPainter*, const QWidget* ) const;
         bool drawFrameTabBarBasePrimitive( const QStyleOption*, QPainter*, const QWidget* ) const;
         bool drawFrameWindowPrimitive( const QStyleOption*, QPainter*, const QWidget* ) const;
+        bool drawWidgetPrimitive(const QStyleOption *, QPainter *, const QWidget *) const;
 
         bool drawIndicatorArrowUpPrimitive( const QStyleOption* option, QPainter* painter, const QWidget* widget ) const
         { return drawIndicatorArrowPrimitive( ArrowUp, option, painter, widget ); }
@@ -523,6 +526,9 @@ namespace Lightly
 
         //* splitter Factory, to extend splitters hit area
         SplitterFactory* _splitterFactory = nullptr;
+
+        //* signal manager for the tools area
+        ToolsAreaManager *_toolsAreaManager = nullptr;
 
         //* widget explorer
         WidgetExplorer* _widgetExplorer = nullptr;

--- a/kstyle/lightlytoolsareamanager.cpp
+++ b/kstyle/lightlytoolsareamanager.cpp
@@ -1,0 +1,264 @@
+#include "lightlytoolsareamanager.h"
+#include "lightlypropertynames.h"
+
+#include <QMainWindow>
+#include <QMdiArea>
+#include <QMenuBar>
+#include <QObject>
+#include <QToolBar>
+#include <QWidget>
+#include <QWindow>
+
+#include <KColorUtils>
+
+const char *colorProperty = "KDE_COLOR_SCHEME_PATH";
+
+namespace Lightly
+{
+ToolsAreaManager::ToolsAreaManager(Helper *helper, QObject *parent)
+    : QObject(parent)
+    , _helper(helper)
+{
+    if (qApp && qApp->property(colorProperty).isValid()) {
+        auto path = qApp->property(colorProperty).toString();
+        _config = KSharedConfig::openConfig(path);
+    } else {
+        _config = KSharedConfig::openConfig();
+    }
+    _watcher = KConfigWatcher::create(_config);
+    connect(_watcher.data(), &KConfigWatcher::configChanged, this, &ToolsAreaManager::configUpdated);
+    configUpdated();
+}
+
+ToolsAreaManager::~ToolsAreaManager()
+{
+}
+
+template<class T1, class T2>
+void appendIfNotAlreadyExists(T1 *list, T2 item)
+{
+    for (auto listItem : *list) {
+        if (listItem == item) {
+            return;
+        }
+    }
+    list->append(item);
+}
+
+void ToolsAreaManager::registerApplication(QApplication *application)
+{
+    _listener = new AppListener(this);
+    _listener->manager = this;
+    if (application->property(colorProperty).isValid()) {
+        auto path = application->property(colorProperty).toString();
+        _config = KSharedConfig::openConfig(path);
+        _watcher = KConfigWatcher::create(_config);
+        connect(_watcher.data(), &KConfigWatcher::configChanged, this, &ToolsAreaManager::configUpdated);
+    }
+    application->installEventFilter(_listener);
+    configUpdated();
+}
+
+QRect ToolsAreaManager::toolsAreaRect(const QMainWindow *window)
+{
+    Q_ASSERT(window);
+
+    int itemHeight = window->menuWidget() ? window->menuWidget()->height() : 0;
+    for (auto item : _windows[window]) {
+        if (!item.isNull() && item->isVisible() && window->toolBarArea(item) == Qt::TopToolBarArea) {
+            itemHeight = qMax(item->mapTo(window, item->rect().bottomLeft()).y(), itemHeight);
+        }
+    }
+    if (itemHeight > 0) {
+        itemHeight += 1;
+    }
+
+    return QRect(0, 0, window->width(), itemHeight);
+}
+
+bool ToolsAreaManager::tryRegisterToolBar(QPointer<QMainWindow> window, QPointer<QWidget> widget)
+{
+    Q_ASSERT(!widget.isNull());
+
+    QPointer<QToolBar> toolbar;
+    if (!(toolbar = qobject_cast<QToolBar *>(widget))) {
+        return false;
+    }
+
+    if (window->toolBarArea(toolbar) == Qt::TopToolBarArea) {
+        widget->setPalette(palette());
+        appendIfNotAlreadyExists(&_windows[window], toolbar);
+        return true;
+    }
+
+    return false;
+}
+
+void ToolsAreaManager::tryUnregisterToolBar(QPointer<QMainWindow> window, QPointer<QWidget> widget)
+{
+    Q_ASSERT(!widget.isNull());
+
+    QPointer<QToolBar> toolbar;
+    if (!(toolbar = qobject_cast<QToolBar *>(widget))) {
+        return;
+    }
+
+    if (window->toolBarArea(toolbar) != Qt::TopToolBarArea) {
+        widget->setPalette(window->palette());
+        _windows[window].removeAll(toolbar);
+    }
+}
+
+void ToolsAreaManager::configUpdated()
+{
+    auto active = KColorScheme(QPalette::Active, KColorScheme::Header, _config);
+    auto inactive = KColorScheme(QPalette::Inactive, KColorScheme::Header, _config);
+    auto disabled = KColorScheme(QPalette::Disabled, KColorScheme::Header, _config);
+
+    _palette = KColorScheme::createApplicationPalette(_config);
+
+    _palette.setBrush(QPalette::Active, QPalette::Window, active.background());
+    _palette.setBrush(QPalette::Active, QPalette::WindowText, active.foreground());
+    _palette.setBrush(QPalette::Disabled, QPalette::Window, disabled.background());
+    _palette.setBrush(QPalette::Disabled, QPalette::WindowText, disabled.foreground());
+    _palette.setBrush(QPalette::Inactive, QPalette::Window, inactive.background());
+    _palette.setBrush(QPalette::Inactive, QPalette::WindowText, inactive.foreground());
+
+    for (auto window : _windows) {
+        for (auto toolbar : window) {
+            if (!toolbar.isNull()) {
+                toolbar->setPalette(_palette);
+            }
+        }
+    }
+
+    _colorSchemeHasHeaderColor = KColorScheme::isColorSetSupported(_config, KColorScheme::Header);
+}
+
+bool AppListener::eventFilter(QObject *watched, QEvent *event)
+{
+    Q_ASSERT(watched);
+    Q_ASSERT(event);
+
+    if (watched != qApp) {
+        return false;
+    }
+
+    if (event->type() == QEvent::DynamicPropertyChange) {
+        if (watched != qApp) {
+            return false;
+        }
+        auto ev = static_cast<QDynamicPropertyChangeEvent *>(event);
+        if (ev->propertyName() == colorProperty) {
+            if (qApp && qApp->property(colorProperty).isValid()) {
+                auto path = qApp->property(colorProperty).toString();
+                manager->_config = KSharedConfig::openConfig(path);
+            } else {
+                manager->_config = KSharedConfig::openConfig();
+            }
+            manager->_watcher = KConfigWatcher::create(manager->_config);
+            connect(manager->_watcher.data(), &KConfigWatcher::configChanged, manager, &ToolsAreaManager::configUpdated);
+            manager->configUpdated();
+        }
+    }
+
+    return false;
+}
+
+bool ToolsAreaManager::eventFilter(QObject *watched, QEvent *event)
+{
+    Q_ASSERT(watched);
+    Q_ASSERT(event);
+
+    QPointer<QObject> parent = watched;
+    QPointer<QMainWindow> mainWindow = nullptr;
+    while (parent != nullptr) {
+        if (qobject_cast<QMainWindow *>(parent)) {
+            mainWindow = qobject_cast<QMainWindow *>(parent);
+            break;
+        }
+        parent = parent->parent();
+    }
+
+    if (QPointer<QMainWindow> mw = qobject_cast<QMainWindow *>(watched)) {
+        QChildEvent *ev = nullptr;
+        if (event->type() == QEvent::ChildAdded || event->type() == QEvent::ChildRemoved) {
+            ev = static_cast<QChildEvent *>(event);
+        }
+
+        QPointer<QToolBar> tb = qobject_cast<QToolBar *>(ev->child());
+        if (tb.isNull()) {
+            return false;
+        }
+
+        if (ev->added()) {
+            if (mw->toolBarArea(tb) == Qt::TopToolBarArea) {
+                appendIfNotAlreadyExists(&_windows[mw], tb);
+            }
+        } else if (ev->removed()) {
+            _windows[mw].removeAll(tb);
+        }
+    } else if (qobject_cast<QToolBar *>(watched)) {
+        if (!mainWindow.isNull()) {
+            tryUnregisterToolBar(mainWindow, qobject_cast<QWidget *>(watched));
+        }
+    }
+
+    return false;
+}
+
+void ToolsAreaManager::registerWidget(QWidget *widget)
+{
+    Q_ASSERT(widget);
+    auto ptr = QPointer<QWidget>(widget);
+
+    auto parent = ptr;
+    QPointer<QMainWindow> mainWindow = nullptr;
+    while (parent != nullptr) {
+        if (qobject_cast<QMdiArea *>(parent) || qobject_cast<QDockWidget *>(parent)) {
+            break;
+        }
+        if (qobject_cast<QMainWindow *>(parent)) {
+            mainWindow = qobject_cast<QMainWindow *>(parent);
+        }
+        parent = parent->parentWidget();
+    }
+    if (mainWindow == nullptr) {
+        return;
+    }
+    if (mainWindow != mainWindow->window()) {
+        return;
+    }
+    tryRegisterToolBar(mainWindow, widget);
+}
+
+void ToolsAreaManager::unregisterWidget(QWidget *widget)
+{
+    Q_ASSERT(widget);
+    auto ptr = QPointer<QWidget>(widget);
+
+    if (QPointer<QMainWindow> window = qobject_cast<QMainWindow *>(ptr)) {
+        _windows.remove(window);
+        return;
+    } else if (QPointer<QToolBar> toolbar = qobject_cast<QToolBar *>(ptr)) {
+        auto parent = ptr;
+        QPointer<QMainWindow> mainWindow = nullptr;
+        while (parent != nullptr) {
+            if (qobject_cast<QMainWindow *>(parent)) {
+                mainWindow = qobject_cast<QMainWindow *>(parent);
+                break;
+            }
+            parent = parent->parentWidget();
+        }
+        if (mainWindow == nullptr) {
+            return;
+        }
+        _windows[mainWindow].removeAll(toolbar);
+    }
+}
+
+bool Lightly::ToolsAreaManager::hasHeaderColors()
+{
+    return _colorSchemeHasHeaderColor;
+}
+}

--- a/kstyle/lightlytoolsareamanager.h
+++ b/kstyle/lightlytoolsareamanager.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "lightlyhelper.h"
+#include "lightlystyle.h"
+#include <KConfigWatcher>
+#include <KSharedConfig>
+#include <QApplication>
+#include <QObject>
+
+namespace Lightly
+{
+class ToolsAreaManager;
+
+// Trying to discriminate QApplication events from events from all QObjects
+// belonging to it is impractical with everything going through a single
+// eventFilter, so we have this class which provides a second one that allows
+// us to filter for the events we want.
+class AppListener : public QObject
+{
+    Q_OBJECT
+    using QObject::QObject;
+
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
+    ToolsAreaManager *manager;
+    friend class ToolsAreaManager;
+};
+
+class ToolsAreaManager : public QObject
+{
+    Q_OBJECT
+
+private:
+    Helper *_helper;
+    QHash<const QMainWindow *, QVector<QPointer<QToolBar>>> _windows;
+    KSharedConfigPtr _config;
+    KConfigWatcher::Ptr _watcher;
+    QPalette _palette = QPalette();
+    AppListener *_listener;
+    bool _colorSchemeHasHeaderColor;
+
+    friend class AppListener;
+
+protected:
+    bool tryRegisterToolBar(QPointer<QMainWindow> window, QPointer<QWidget> widget);
+    void tryUnregisterToolBar(QPointer<QMainWindow> window, QPointer<QWidget> widget);
+    void configUpdated();
+
+public:
+    explicit ToolsAreaManager(Helper *helper, QObject *parent = nullptr);
+    ~ToolsAreaManager();
+
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
+    const QPalette &palette() const
+    {
+        return _palette;
+    }
+
+    void registerApplication(QApplication *application);
+    void registerWidget(QWidget *widget);
+    void unregisterWidget(QWidget *widget);
+
+    QRect toolsAreaRect(const QMainWindow *window);
+
+    bool hasHeaderColors();
+};
+}


### PR DESCRIPTION
This should close (potentially) #43 and #42 

**If this is merged please note the following.**

The feature-qt6 branch will contain changes for #20, #43 and #42

---
### 43 Menubar transparency

Tested using the Glassly and Glassly-Darker theme https://store.kde.org/p/1652008

Changes made:

- Added UI config to adjust menubar opacity levels, and this only works on color schemes which use alpha channels it has no effect on color schemes for example Breeze Light

![config](https://github.com/user-attachments/assets/3876fd27-cf3d-4eb4-90da-61f75330affc)

- Kate was remaining opaque due to it being included in the ForceOpaque StringList found inside file lightly.kcfg this entry has now been removed
- Hovering over the sliders shows a tooltip giving a description of the purpose

Kate now shows a full transparent menubar

![kate](https://github.com/user-attachments/assets/3b39366e-af9b-43b9-b932-fd2c0f77a291)


---
### 42 Make toolbar use darker gray tone

Changes made:

- Aligned code with Breeze; this is the same code being used in Brise and Klassy too
- The toolbars now go a slighter darker gray tone if the color scheme is set to Breeze Light

![kate_after](https://github.com/user-attachments/assets/a334518d-5406-4980-b7f3-a063dc14cee2)