### PR TITLE
Dolphin capacity status bar issue on Archlinux

### DIFF
--- a/.github/assets/pkgbuild/PKGBUILD
+++ b/.github/assets/pkgbuild/PKGBUILD
@@ -26,8 +26,6 @@ source=(
     "${pkgname}.git::git+${url}.git#tag=v${pkgver//_/-}"
 )
 
-# use makepkg -g to generate the sha256sum for the release tag
-
 # KF6/QT6
 depends_kf6=(
     'kdecoration'
@@ -84,6 +82,6 @@ build() (
 
 package() (
     install -dm755 "$pkgdir.git"
-    DESTDIR="$pkgdir" cmake --install build_kf6
+    DESTDIR="$pkgdir" cmake --install $build_dir
     rm -rf "$pkgdir/usr/lib/cmake"
 )

--- a/.github/workflows/archlinux.yml
+++ b/.github/workflows/archlinux.yml
@@ -24,7 +24,7 @@ jobs:
         run: pacman -Syu --noconfirm
       - name: Install sudo, git and compile dependencies
         run: |
-          pacman -Sy sudo git binutils make gcc pkg-config fakeroot \
+          pacman -Sy sudo git binutils make gcc pkg-config fakeroot plasma-desktop \
           cmake extra-cmake-modules qt6-base \
           kdecoration qt6-declarative kcoreaddons \
           kcmutils kcolorscheme kconfig kguiaddons \


### PR DESCRIPTION
I noticed after installing the release asset from https://github.com/Bali10050/Lightly/releases/download/v0.5.8/lightly-0.5.8-x86_64.pkg.zst
The capacity status bar is not correct.

This impacts the AUR package `lightly-qt6-bin` too.

![dolphin_capacity](https://github.com/user-attachments/assets/11bee91c-c1fa-4541-a704-df97815d397f)

The Archlinux docker container which the GitHub action workflow uses to generate the .zst file was missing the `plasma-desktop` package.
This PR fixes things.