### PR TITLE
Make rubber band frame rounded

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 project(lightly)
-set(PROJECT_VERSION "0.5.10")
+set(PROJECT_VERSION "0.5.11")
 set(PROJECT_VERSION_MAJOR 6)
 
 set(KF5_MIN_VERSION "5.102.0")

--- a/kstyle/config/lightlystyleconfig.cpp
+++ b/kstyle/config/lightlystyleconfig.cpp
@@ -54,6 +54,7 @@ namespace Lightly
         connect( _titleWidgetDrawFrame, &QAbstractButton::toggled, this, &StyleConfig::updateChanged );
         connect( _sidePanelDrawFrame, &QAbstractButton::toggled, this, &StyleConfig::updateChanged );
         connect( _menuItemDrawThinFocus, &QAbstractButton::toggled, this, &StyleConfig::updateChanged );
+        connect(_roundedRubberBandFrame, &QAbstractButton::toggled, this, &StyleConfig::updateChanged);
         connect( _mnemonicsMode, SIGNAL(currentIndexChanged(int)), SLOT(updateChanged()) );
         connect( _animationsEnabled, &QAbstractButton::toggled, this, &StyleConfig::updateChanged );
         connect( _animationsDuration, SIGNAL(valueChanged(int)), SLOT(updateChanged()) );
@@ -93,6 +94,7 @@ namespace Lightly
         StyleConfigData::setTitleWidgetDrawFrame( _titleWidgetDrawFrame->isChecked() );
         StyleConfigData::setSidePanelDrawFrame( _sidePanelDrawFrame->isChecked() );
         StyleConfigData::setMenuItemDrawStrongFocus( !_menuItemDrawThinFocus->isChecked() );
+        StyleConfigData::setRoundedRubberBandFrame(_roundedRubberBandFrame->isChecked());
         StyleConfigData::setMnemonicsMode( _mnemonicsMode->currentIndex() );
         StyleConfigData::setScrollBarAddLineButtons( _scrollBarAddLineButtons->currentIndex() );
         StyleConfigData::setScrollBarSubLineButtons( _scrollBarSubLineButtons->currentIndex() );
@@ -150,6 +152,8 @@ namespace Lightly
         else if( _titleWidgetDrawFrame->isChecked() != StyleConfigData::titleWidgetDrawFrame() ) modified = true;
         else if( _sidePanelDrawFrame->isChecked() != StyleConfigData::sidePanelDrawFrame() ) modified = true;
         else if( _menuItemDrawThinFocus->isChecked() == StyleConfigData::menuItemDrawStrongFocus() ) modified = true;
+        else if (_roundedRubberBandFrame->isChecked() == StyleConfigData::roundedRubberBandFrame())
+            modified = true;
         else if( _mnemonicsMode->currentIndex() != StyleConfigData::mnemonicsMode() ) modified = true;
         else if( _scrollBarAddLineButtons->currentIndex() != StyleConfigData::scrollBarAddLineButtons() ) modified = true;
         else if( _scrollBarSubLineButtons->currentIndex() != StyleConfigData::scrollBarSubLineButtons() ) modified = true;
@@ -193,6 +197,7 @@ namespace Lightly
         _titleWidgetDrawFrame->setChecked( StyleConfigData::titleWidgetDrawFrame() );
         _sidePanelDrawFrame->setChecked( StyleConfigData::sidePanelDrawFrame() );
         _menuItemDrawThinFocus->setChecked( !StyleConfigData::menuItemDrawStrongFocus() );
+        _roundedRubberBandFrame->setChecked(StyleConfigData::roundedRubberBandFrame());
         _mnemonicsMode->setCurrentIndex( StyleConfigData::mnemonicsMode() );
         _scrollBarAddLineButtons->setCurrentIndex( StyleConfigData::scrollBarAddLineButtons() );
         _scrollBarSubLineButtons->setCurrentIndex( StyleConfigData::scrollBarSubLineButtons() );

--- a/kstyle/config/ui/lightlystyleconfig.ui
+++ b/kstyle/config/ui/lightlystyleconfig.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>772</width>
-    <height>534</height>
+    <height>545</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -471,6 +471,16 @@
         <widget class="QCheckBox" name="_menuItemDrawThinFocus">
          <property name="text">
           <string>Draw a thin line to indicate focus in menus and menubars</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="_roundedRubberBandFrame">
+         <property name="toolTip">
+          <string>This makes the selection rectangle frame rounded</string>
+         </property>
+         <property name="text">
+          <string>Draw rounded frame on rubber band control</string>
          </property>
         </widget>
        </item>

--- a/kstyle/lightly.kcfg
+++ b/kstyle/lightly.kcfg
@@ -178,6 +178,10 @@
       <default>true</default>
     </entry>
 
+    <entry name="RoundedRubberBandFrame" type="Bool">
+      <default>false</default>
+    </entry>
+
     <!-- window dragging -->
     <entry name="WindowDragMode" type="Enum">
       <choices>

--- a/kstyle/lightlystyle.cpp
+++ b/kstyle/lightlystyle.cpp
@@ -75,7 +75,7 @@
 #include <QQuickWindow>
 #endif
 
-//#include <QDebug>
+#include <QDebug>
 
 namespace LightlyPrivate
 {
@@ -6327,18 +6327,33 @@ Style::Style()
     //___________________________________________________________________________________
     bool Style::drawRubberBandControl( const QStyleOption* option, QPainter* painter, const QWidget* ) const
     {
-
+        qDebug() << StyleConfigData::roundedRubberBandFrame();
         painter->save();
 
         painter->setRenderHints( QPainter::Antialiasing );
         const auto& palette( option->palette );
         auto color = palette.color( QPalette::Highlight );
-        QPen pen = KColorUtils::mix( color, palette.color( QPalette::Active, QPalette::WindowText ) );
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QPen pen = KColorUtils::lighten(palette.color(QPalette::Accent));
+#else
+        QPen pen = KColorUtils::lighten(palette.color(QPalette::Highlight));
+#endif
+
+        if (!StyleConfigData::roundedRubberBandFrame()) {
+            QPen pen = KColorUtils::mix(color, palette.color(QPalette::Active, QPalette::WindowText));
+        }
+
         pen.setJoinStyle(Qt::RoundJoin);
         painter->setPen( pen );
         color.setAlpha( 51 ); // 20% opacity
         painter->setBrush( color );
-        painter->drawRect( _helper->strokedRect( option->rect ) );
+        if (StyleConfigData::roundedRubberBandFrame()) {
+            painter->drawRoundedRect(_helper->strokedRect(option->rect), StyleConfigData::cornerRadius(), StyleConfigData::cornerRadius());
+
+        } else {
+            painter->drawRect(_helper->strokedRect(option->rect));
+        }
 
         painter->restore();
         return true;

--- a/kstyle/lightlystyle.cpp
+++ b/kstyle/lightlystyle.cpp
@@ -75,7 +75,7 @@
 #include <QQuickWindow>
 #endif
 
-#include <QDebug>
+// #include <QDebug>
 
 namespace LightlyPrivate
 {
@@ -6327,7 +6327,6 @@ Style::Style()
     //___________________________________________________________________________________
     bool Style::drawRubberBandControl( const QStyleOption* option, QPainter* painter, const QWidget* ) const
     {
-        qDebug() << StyleConfigData::roundedRubberBandFrame();
         painter->save();
 
         painter->setRenderHints( QPainter::Antialiasing );
@@ -6357,7 +6356,6 @@ Style::Style()
 
         painter->restore();
         return true;
-
     }
 
     //___________________________________________________________________________________


### PR DESCRIPTION
#66 

"Rubber band" aka rectangle selector frame.

![lightly_settings](https://github.com/user-attachments/assets/2923a134-641a-4733-b0f0-f0e5732dd8ae)

By default it the setting is disabled.

It uses the `StyleConfigData::cornerRadius()` to draw the rectangle edges.

Now it looks like.

![rounded](https://github.com/user-attachments/assets/0448bd9e-3f99-4a46-ac39-5c85bdf96eea)

