### PR TITLE
Active shadow on radio button

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 project(lightly)
-set(PROJECT_VERSION "0.5.10")
+set(PROJECT_VERSION "0.5.11")
 set(PROJECT_VERSION_MAJOR 6)
 
 set(KF5_MIN_VERSION "5.102.0")

--- a/kstyle/lightlyhelper.cpp
+++ b/kstyle/lightlyhelper.cpp
@@ -651,6 +651,9 @@ namespace Lightly
         const int size, const float param1, const float param2, 
         const int xOffset, const int yOffset, const bool outline, const int outlineStrength ) const
     {
+        if (!StyleConfigData::widgetDrawShadow())
+            return;
+
         painter->setPen( Qt::NoPen );
         
         if (outline) { 


### PR DESCRIPTION
#67 

If Draw widget shadow is unchecked then there is no need to draw the shadow effect.

![radio](https://github.com/user-attachments/assets/219b2ddb-ab65-4908-a0b7-9fdd17a75b31)
